### PR TITLE
在庫変動履歴機能を拡張し備考欄とユーザー管理方式を改善

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,4 +71,6 @@ Write-Utf8NoBom -Path $file -Content ($old+"`nYOUR_TEXT_HERE`n")
 - エラーハンドラーを利用して、エラー処理を行う
 - htmlへの直接記載ではなく、CSSを利用する
 - bootstrap利用してください。
-
+- JS処理は、JSファイルへ集約する
+- コントローラー、サービス、リポジトリは、処理の責務を分ける
+- @DataJpaTestは利用しないで、＠SpringBootTestを利用する

--- a/src/main/java/com/inventory/inventory_management/entity/StockTransaction.java
+++ b/src/main/java/com/inventory/inventory_management/entity/StockTransaction.java
@@ -1,0 +1,80 @@
+package com.inventory.inventory_management.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 在庫変動履歴エンティティ
+ * stock_transactionsテーブルに対応
+ */
+@Entity
+@Table(name = "stock_transactions")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StockTransaction {
+
+    /**
+     * トランザクションID（主キー）
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    /**
+     * 商品ID（外部キー）
+     */
+    @Column(name = "product_id", nullable = false)
+    private Integer productId;
+
+    /**
+     * 取引種別（in: 入庫、out: 出庫）
+     */
+    @Column(name = "transaction_type", length = 10, nullable = false)
+    private String transactionType;
+
+    /**
+     * 数量
+     */
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    /**
+     * 変更前在庫数
+     */
+    @Column(name = "before_stock", nullable = false)
+    private Integer beforeStock;
+
+    /**
+     * 変更後在庫数
+     */
+    @Column(name = "after_stock", nullable = false)
+    private Integer afterStock;
+
+    /**
+     * 実行ユーザーID
+     */
+    @Column(name = "user_id", length = 50, nullable = false)
+    private String userId;
+
+    /**
+     * 取引日時
+     */
+    @Column(name = "transaction_date", nullable = false)
+    private LocalDateTime transactionDate;
+
+    /**
+     * 備考
+     */
+    @Column(name = "remarks", length = 255)
+    private String remarks;
+}

--- a/src/main/java/com/inventory/inventory_management/repository/ProductRepository.java
+++ b/src/main/java/com/inventory/inventory_management/repository/ProductRepository.java
@@ -34,9 +34,9 @@ public interface ProductRepository extends JpaRepository<Product, Integer> {
      * @return 検索結果のページ
      */
     @Query("SELECT p FROM Product p WHERE " +
-           "(:keyword IS NULL OR LOWER(p.productName) LIKE LOWER(CONCAT('%', :keyword, '%'))) AND " +
-           "(:category IS NULL OR p.category = :category) AND " +
-           "(:status IS NULL OR p.status = :status) AND " +
+           "(:keyword IS NULL OR :keyword = '' OR LOWER(p.productName) LIKE LOWER(CONCAT('%', :keyword, '%'))) AND " +
+           "(:category IS NULL OR :category = '' OR p.category = :category) AND " +
+           "(:status IS NULL OR :status = '' OR p.status = :status) AND " +
            "p.deletedAt IS NULL")
     Page<Product> findBySearchConditions(
         @Param("keyword") String keyword,
@@ -70,9 +70,9 @@ public interface ProductRepository extends JpaRepository<Product, Integer> {
      * @return 検索結果のページ
      */
     @Query("SELECT p FROM Product p WHERE " +
-           "(:keyword IS NULL OR LOWER(p.productName) LIKE LOWER(CONCAT('%', :keyword, '%'))) AND " +
-           "(:category IS NULL OR p.category = :category) AND " +
-           "(:status IS NULL OR p.status = :status) AND " +
+           "(:keyword IS NULL OR :keyword = '' OR LOWER(p.productName) LIKE LOWER(CONCAT('%', :keyword, '%'))) AND " +
+           "(:category IS NULL OR :category = '' OR p.category = :category) AND " +
+           "(:status IS NULL OR :status = '' OR p.status = :status) AND " +
            "(:minStock IS NULL OR p.stock >= :minStock) AND " +
            "(:maxStock IS NULL OR p.stock <= :maxStock) AND " +
            "p.deletedAt IS NULL")

--- a/src/main/java/com/inventory/inventory_management/repository/StockTransactionRepository.java
+++ b/src/main/java/com/inventory/inventory_management/repository/StockTransactionRepository.java
@@ -1,0 +1,38 @@
+package com.inventory.inventory_management.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.inventory.inventory_management.entity.StockTransaction;
+
+/**
+ * 在庫変動履歴リポジトリ
+ * 在庫変動履歴データのCRUD操作を提供
+ */
+@Repository
+public interface StockTransactionRepository extends JpaRepository<StockTransaction, Integer> {
+
+    /**
+     * 商品IDで在庫変動履歴を検索（日時降順）
+     * @param productId 商品ID
+     * @return 在庫変動履歴リスト
+     */
+    @Query("SELECT st FROM StockTransaction st WHERE st.productId = :productId ORDER BY st.transactionDate DESC")
+    List<StockTransaction> findByProductIdOrderByTransactionDateDesc(@Param("productId") Integer productId);
+
+    /**
+     * 商品IDと取引種別で在庫変動履歴を検索
+     * @param productId 商品ID
+     * @param transactionType 取引種別（in/out）
+     * @return 在庫変動履歴リスト
+     */
+    @Query("SELECT st FROM StockTransaction st WHERE st.productId = :productId AND st.transactionType = :transactionType ORDER BY st.transactionDate DESC")
+    List<StockTransaction> findByProductIdAndTransactionType(
+        @Param("productId") Integer productId,
+        @Param("transactionType") String transactionType
+    );
+}

--- a/src/main/java/com/inventory/inventory_management/security/SecurityConfig.java
+++ b/src/main/java/com/inventory/inventory_management/security/SecurityConfig.java
@@ -102,6 +102,7 @@ public class SecurityConfig {
            })
            .csrf((csrf) -> csrf
                .csrfTokenRepository(csrfTokenRepository)  // CSRF保護の明示的な設定（セッションベース）
+               .ignoringRequestMatchers("/csp-violation-report-endpoint")  // CSPレポートエンドポイントをCSRF保護から除外
            )
            .sessionManagement((session) -> {
                session

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -10208,3 +10208,45 @@ INSERT IGNORE INTO products (product_code, product_name, category, description, 
 ('RPYLOB1M', 'Headphones', 'Clothing', 'Product_K3M9M', 411.63, 79, 1, '17x11x17 cm', '2023-07-30', '2026-01-01', 'INSC1B', '0QB,U55', 'Red/Small', 1, 'active'),
 ('3JWTGTOM', 'Laptop', 'Clothing', 'Product_I0ACF', 74.38, 81, 1, '6x6x16 cm', '2023-01-01', '2025-01-01', 'UH0U3R', 'C5R,TZN', 'Blue/Medium', 1, 'active');
 
+-- Update stock to 0 for 30 items
+UPDATE products
+SET stock = 0
+WHERE product_code IN (
+	'93TGNAY7', 'TYYZ5AV7', '5C94FGTQ', 'XBHKYPQB', '728GCZFU',
+	'27R9M103', 'JDOVOMY2', '0KHFMXFN', 'T4F2EW7G', 'GL199BEL',
+	'SX7HALUU', '1AOXE5QW', 'KOXR70B4', 'X2D1GWO5', 'ZKI2USNA',
+	'EPKS7ECS', 'UB8UO1PA', '6ID782KK', 'YWJW03Z5', '44WFTM8R',
+	'CVYLYMJ3', '9UQRU4ZU', '4RBD28EN', 'XNTCQGCN', 'T27XMDD2',
+	'OR97MBZ1', 'HGFIOVL2', '758FMQ42', '8XJVYL79', 'YWS54ZGS'
+);
+
+-- Mark 10 items as inactive
+UPDATE products
+SET status = 'inactive'
+WHERE product_code IN (
+	'93TGNAY7', 'TYYZ5AV7', '5C94FGTQ', 'XBHKYPQB', '728GCZFU',
+	'27R9M103', 'JDOVOMY2', '0KHFMXFN', 'T4F2EW7G', 'GL199BEL'
+);
+
+-- Mark 10 items with stock greater than 1 as inactive using JOIN
+UPDATE products p
+JOIN (
+	SELECT product_code
+	FROM products
+	WHERE stock > 1
+	LIMIT 10
+) sub ON p.product_code = sub.product_code
+SET p.status = 'inactive';
+
+-- 在庫履歴データ（remarksカラムを含む）
+-- 注: 実際の運用環境では、これらのサンプルデータは不要な場合があります
+INSERT INTO stock_transactions (product_id, transaction_type, quantity, before_stock, after_stock, user_id, transaction_date, remarks) VALUES
+-- commercial_Laptop (product_code: '93TGNAY7') の在庫履歴
+((SELECT id FROM products WHERE product_code = '93TGNAY7'), 'in', 50, 0, 50, 'testuser', '2023-01-15 10:00:00', '初期在庫入庫'),
+((SELECT id FROM products WHERE product_code = '93TGNAY7'), 'out', 47, 50, 3, 'testuser', '2023-06-20 14:30:00', '販売による出庫'),
+-- Smartphone (product_code: 'TYYZ5AV7') の在庫履歴
+((SELECT id FROM products WHERE product_code = 'TYYZ5AV7'), 'in', 100, 0, 100, 'testuser', '2023-03-20 09:00:00', '初期在庫入庫'),
+((SELECT id FROM products WHERE product_code = 'TYYZ5AV7'), 'out', 8, 100, 92, 'testuser', '2023-08-15 16:45:00', '販売による出庫'),
+-- Headphones (product_code: '5C94FGTQ') の在庫履歴
+((SELECT id FROM products WHERE product_code = '5C94FGTQ'), 'in', 30, 0, 30, 'adminuser', '2023-03-20 11:30:00', '初期在庫入庫'),
+((SELECT id FROM products WHERE product_code = '5C94FGTQ'), 'out', 11, 30, 19, 'adminuser', '2023-09-10 13:20:00', '販売による出庫');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -64,17 +64,16 @@ CREATE TABLE IF NOT EXISTS products (
 CREATE TABLE IF NOT EXISTS stock_transactions (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     product_id INT NOT NULL,
-    transaction_type VARCHAR(20) NOT NULL,
+    transaction_type VARCHAR(10) NOT NULL,
     quantity INTEGER NOT NULL,
     before_stock INTEGER NOT NULL,
     after_stock INTEGER NOT NULL,
-    user_id INT NOT NULL,
-    user_name VARCHAR(100) NOT NULL,
-    note VARCHAR(255) NULL,
+    user_id VARCHAR(50) NOT NULL,
     transaction_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    remarks VARCHAR(255) NULL,
     FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT ON UPDATE CASCADE,
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT ON UPDATE CASCADE,
-    CHECK (transaction_type IN ('IN', 'OUT', 'ADJUST')),
+    CHECK (transaction_type IN ('in', 'out')),
+    CHECK (quantity > 0),
     CHECK (before_stock >= 0),
     CHECK (after_stock >= 0)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -235,3 +235,65 @@ body.error-page .login-container {
 .error-icon {
     font-size: 4rem;
 }
+
+/* テーブル列の幅指定 */
+.w-8 {
+    width: 8%;
+}
+
+.w-10 {
+    width: 10%;
+}
+
+.w-12 {
+    width: 12%;
+}
+
+.w-13 {
+    width: 13%;
+}
+
+.w-15 {
+    width: 15%;
+}
+
+.w-18 {
+    width: 18%;
+}
+
+.w-20 {
+    width: 20%;
+}
+
+.w-40 {
+    width: 40%;
+}
+
+.w-50 {
+    width: 50%;
+}
+
+/* インラインフォーム用スタイル */
+.form-inline {
+    display: inline;
+}
+
+/* リンクボタンのインライン表示 */
+.btn-link-inline {
+    display: inline;
+    padding: 0;
+    border: none;
+}
+
+/* ステータスバッジ */
+.badge-status-active {
+    background-color: #e7f5ff;
+    color: #212529;
+    border: 1px solid #74c0fc;
+}
+
+.badge-status-inactive {
+    background-color: #dc3545;
+    color: #ffffff;
+    font-weight: 600;
+}

--- a/src/main/resources/static/images/favicon.svg
+++ b/src/main/resources/static/images/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- 背景円 -->
+  <circle cx="32" cy="32" r="32" fill="#0d6efd"/>
+  
+  <!-- 箱のデザイン（在庫管理を象徴） -->
+  <g transform="translate(32, 32)">
+    <!-- 箱の上面 -->
+    <path d="M -12,-8 L 0,-14 L 12,-8 L 0,-2 Z" fill="#ffffff" opacity="0.9"/>
+    
+    <!-- 箱の左側面 -->
+    <path d="M -12,-8 L -12,8 L 0,14 L 0,-2 Z" fill="#ffffff" opacity="0.7"/>
+    
+    <!-- 箱の右側面 -->
+    <path d="M 0,-2 L 0,14 L 12,8 L 12,-8 Z" fill="#ffffff" opacity="0.5"/>
+    
+    <!-- チェックマーク（管理済みを表現） -->
+    <g transform="translate(0, 0)">
+      <path d="M -5,0 L -2,3 L 5,-5" fill="none" stroke="#ffc107" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+  </g>
+</svg>

--- a/src/main/resources/static/js/inventory.js
+++ b/src/main/resources/static/js/inventory.js
@@ -1,0 +1,162 @@
+/**
+ * 在庫管理画面用JavaScript
+ * 在庫モーダルの入庫・出庫処理を管理
+ */
+
+document.addEventListener('DOMContentLoaded', function() {
+    const stockModal = document.getElementById('stockModal');
+    
+    // モーダルが存在しない場合は処理を終了
+    if (!stockModal) {
+        return;
+    }
+    
+    const stockInput = document.getElementById('stockInput');
+    let currentProductId = null;
+    let currentProductName = null;
+    let currentStock = null;
+    let stockUpdated = false; // 在庫更新成功フラグ
+
+    // CSRFトークンをHTMLのdata属性から取得
+    const csrfToken = document.body.getAttribute('data-csrf-token');
+    const csrfHeader = document.body.getAttribute('data-csrf-header');
+
+    /**
+     * メッセージを表示する関数
+     */
+    function showMessage(message, type) {
+        const messageDiv = document.getElementById('stockModalMessage');
+        messageDiv.className = 'alert alert-' + type;
+        messageDiv.textContent = message;
+        messageDiv.classList.remove('d-none');
+    }
+
+    /**
+     * メッセージを非表示にする関数
+     */
+    function hideMessage() {
+        const messageDiv = document.getElementById('stockModalMessage');
+        messageDiv.classList.add('d-none');
+    }
+
+    /**
+     * モーダルが開かれたときの処理
+     */
+    stockModal.addEventListener('show.bs.modal', function(event) {
+        const button = event.relatedTarget;
+        currentProductId = button.getAttribute('data-product-id');
+        currentProductName = button.getAttribute('data-product-name');
+        currentStock = parseInt(button.getAttribute('data-current-stock'));
+
+        // モーダルのタイトルを更新
+        const modalTitle = stockModal.querySelector('.modal-title');
+        modalTitle.textContent = '在庫管理 - ' + currentProductName + ' (現在: ' + currentStock + '個)';
+
+        // 入力フィールドをリセット
+        stockInput.value = '';
+        document.getElementById('stockIn').checked = true;
+        
+        // メッセージを非表示
+        hideMessage();
+        
+        // 在庫更新フラグをリセット
+        stockUpdated = false;
+    });
+
+    /**
+     * モーダルが閉じられた後の処理
+     * 注: ページリロードではなく、DOM更新で在庫数を反映
+     */
+    stockModal.addEventListener('hidden.bs.modal', function() {
+        // 在庫更新フラグをリセット
+        stockUpdated = false;
+    });
+
+    /**
+     * モーダルの更新ボタンクリック処理
+     */
+    const updateButton = stockModal.querySelector('.btn-primary');
+    updateButton.addEventListener('click', function() {
+        const operation = document.querySelector('input[name="stockOperation"]:checked').value;
+        const amount = parseInt(stockInput.value);
+
+        // バリデーション
+        if (!amount || amount <= 0) {
+            showMessage('有効な在庫数を入力してください。', 'warning');
+            return;
+        }
+
+        // 出庫の場合、在庫数チェック
+        if (operation === 'out' && amount > currentStock) {
+            showMessage('出庫数は現在の在庫数（' + currentStock + '個）以下で入力してください。', 'warning');
+            return;
+        }
+        
+        // メッセージを非表示
+        hideMessage();
+
+        // 更新ボタンを無効化（二重送信防止）
+        updateButton.disabled = true;
+        updateButton.textContent = '更新中...';
+
+        // サーバーへのリクエスト
+        fetch('/api/inventory/update-stock', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                [csrfHeader]: csrfToken
+            },
+            body: JSON.stringify({
+                productId: parseInt(currentProductId),
+                transactionType: operation,
+                quantity: amount,
+                remarks: (operation === 'in' ? '入庫' : '出庫') + '処理'
+            })
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                // 成功メッセージを表示
+                showMessage(data.message + ' (新しい在庫数: ' + data.product.stock + '個)', 'success');
+                
+                // 在庫更新成功フラグを設定
+                stockUpdated = true;
+                
+                // ボタンを再有効化
+                updateButton.disabled = false;
+                updateButton.textContent = '更新';
+                
+                // 入力フィールドとラジオボタンをリセット
+                stockInput.value = '';
+                document.getElementById('stockIn').checked = true;
+                
+                // 現在の在庫数を更新
+                currentStock = data.product.stock;
+                
+                // モーダルのタイトルを更新
+                const modalTitle = stockModal.querySelector('.modal-title');
+                modalTitle.textContent = '在庫管理 - ' + currentProductName + ' (現在: ' + currentStock + '個)';
+                
+                // 【DOM更新】ページ上の在庫数表示を更新（リロードなし）
+                const stockLink = document.querySelector('a.stock-link[data-product-id="' + currentProductId + '"]');
+                if (stockLink) {
+                    stockLink.textContent = data.product.stock;
+                    stockLink.setAttribute('data-current-stock', data.product.stock);
+                }
+            } else {
+                // エラーメッセージを表示
+                showMessage('エラー: ' + data.message, 'danger');
+                // ボタンを再有効化
+                updateButton.disabled = false;
+                updateButton.textContent = '更新';
+            }
+        })
+        .catch(error => {
+            console.error('エラー:', error);
+            showMessage('在庫更新に失敗しました。システム管理者に連絡してください。', 'danger');
+            // ボタンを再有効化
+            updateButton.disabled = false;
+            updateButton.textContent = '更新';
+        });
+    });
+});

--- a/src/main/resources/templates/admin/inventory.html
+++ b/src/main/resources/templates/admin/inventory.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>在庫管理 - 商品在庫管理システム</title>
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
@@ -44,8 +47,8 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <form action="/logout" method="post" style="display: inline;">
-                            <button type="submit" class="btn btn-link nav-link" style="display: inline; padding: 0; border: none;">
+                        <form action="/logout" method="post" class="form-inline">
+                            <button type="submit" class="btn btn-link nav-link btn-link-inline">
                                 <i class="bi bi-box-arrow-right"></i> ログアウト
                             </button>
                         </form>
@@ -148,14 +151,14 @@
                             <table class="table table-hover align-middle">
                                 <thead class="table-light">
                                     <tr>
-                                        <th style="width: 10%;">商品ID</th>
-                                        <th style="width: 20%;">商品名</th>
-                                        <th style="width: 12%;">カテゴリ</th>
-                                        <th style="width: 10%;">価格</th>
-                                        <th style="width: 10%;">在庫数</th>
-                                        <th style="width: 10%;">ステータス</th>
-                                        <th style="width: 10%;">更新日</th>
-                                        <th style="width: 18%;">操作</th>
+                                        <th class="w-10">商品ID</th>
+                                        <th class="w-20">商品名</th>
+                                        <th class="w-12">カテゴリ</th>
+                                        <th class="w-10">価格</th>
+                                        <th class="w-10">在庫数</th>
+                                        <th class="w-10">ステータス</th>
+                                        <th class="w-10">更新日</th>
+                                        <th class="w-18">操作</th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>管理者ログイン - 商品在庫管理システム</title>
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Custom CSS -->

--- a/src/main/resources/templates/admin/menu.html
+++ b/src/main/resources/templates/admin/menu.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>管理者メニュー - 商品在庫管理システム</title>
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
@@ -54,7 +57,7 @@
         </div>
 
         <div class="logout-section">
-            <form th:action="@{/logout}" method="post" style="display: inline;">
+            <form th:action="@{/logout}" method="post" class="form-inline">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <button type="submit" class="btn-logout">
                     <i class="bi bi-box-arrow-right"></i> ログアウト

--- a/src/main/resources/templates/admin/product-create.html
+++ b/src/main/resources/templates/admin/product-create.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>商品新規登録 - 商品在庫管理システム</title>
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
@@ -44,8 +47,8 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <form action="/logout" method="post" style="display: inline;">
-                            <button type="submit" class="btn btn-link nav-link" style="display: inline; padding: 0; border: none;">
+                        <form action="/logout" method="post" class="form-inline">
+                            <button type="submit" class="btn btn-link nav-link btn-link-inline">
                                 <i class="bi bi-box-arrow-right"></i> ログアウト
                             </button>
                         </form>

--- a/src/main/resources/templates/admin/product-detail.html
+++ b/src/main/resources/templates/admin/product-detail.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>商品詳細 - 商品在庫管理システム</title>
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
@@ -44,8 +47,8 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <form action="/logout" method="post" style="display: inline;">
-                            <button type="submit" class="btn btn-link nav-link" style="display: inline; padding: 0; border: none;">
+                        <form action="/logout" method="post" class="form-inline">
+                            <button type="submit" class="btn btn-link nav-link btn-link-inline">
                                 <i class="bi bi-box-arrow-right"></i> ログアウト
                             </button>
                         </form>
@@ -93,7 +96,7 @@
                             <div class="col-md-6">
                                 <table class="table table-borderless">
                                     <tr>
-                                        <th style="width: 40%;">商品コード (Product Code)</th>
+                                        <th class="w-40">商品コード (Product Code)</th>
                                         <td><code>93TGNAY7</code></td>
                                     </tr>
                                     <tr>
@@ -117,7 +120,7 @@
                             <div class="col-md-6">
                                 <table class="table table-borderless">
                                     <tr>
-                                        <th style="width: 40%;">価格 (Price)</th>
+                                        <th class="w-40">価格 (Price)</th>
                                         <td><strong class="text-primary">¥253.17</strong></td>
                                     </tr>
                                     <tr>
@@ -161,7 +164,7 @@
                             <div class="col-md-6">
                                 <table class="table table-borderless">
                                     <tr>
-                                        <th style="width: 50%;">保証期間 (Warranty Period)</th>
+                                        <th class="w-50">保証期間 (Warranty Period)</th>
                                         <td>2年</td>
                                     </tr>
                                     <tr>
@@ -177,7 +180,7 @@
                             <div class="col-md-6">
                                 <table class="table table-borderless">
                                     <tr>
-                                        <th style="width: 50%;">製造日 (Manufacturing Date)</th>
+                                        <th class="w-50">製造日 (Manufacturing Date)</th>
                                         <td>2023-01-01</td>
                                     </tr>
                                     <tr>

--- a/src/main/resources/templates/admin/products.html
+++ b/src/main/resources/templates/admin/products.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>商品管理 - 商品在庫管理システム</title>
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
@@ -44,8 +47,8 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <form action="/logout" method="post" style="display: inline;">
-                            <button type="submit" class="btn btn-link nav-link" style="display: inline; padding: 0; border: none;">
+                        <form action="/logout" method="post" class="form-inline">
+                            <button type="submit" class="btn btn-link nav-link btn-link-inline">
                                 <i class="bi bi-box-arrow-right"></i> ログアウト
                             </button>
                         </form>
@@ -142,14 +145,14 @@
                             <table class="table table-hover align-middle">
                                 <thead class="table-light">
                                     <tr>
-                                        <th style="width: 10%;">商品ID</th>
-                                        <th style="width: 20%;">商品名</th>
-                                        <th style="width: 12%;">カテゴリ</th>
-                                        <th style="width: 10%;">価格</th>
-                                        <th style="width: 8%;">在庫数</th>
-                                        <th style="width: 10%;">ステータス</th>
-                                        <th style="width: 15%;">更新日</th>
-                                        <th style="width: 15%;">操作</th>
+                                        <th class="w-10">商品ID</th>
+                                        <th class="w-20">商品名</th>
+                                        <th class="w-12">カテゴリ</th>
+                                        <th class="w-10">価格</th>
+                                        <th class="w-8">在庫数</th>
+                                        <th class="w-10">ステータス</th>
+                                        <th class="w-15">更新日</th>
+                                        <th class="w-15">操作</th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>エラー - 商品在庫管理システム</title>
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" 
           rel="stylesheet" 

--- a/src/main/resources/templates/inventory.html
+++ b/src/main/resources/templates/inventory.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>在庫管理 - 商品在庫管理システム</title>
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
@@ -15,11 +18,11 @@
     <!-- 共通JavaScript -->
     <script src="/js/common.js"></script>
 </head>
-<body>
+<body th:data-csrf-token="${_csrf.token}" th:data-csrf-header="${_csrf.headerName}">
     <!-- ナビゲーションバー -->
     <nav class="navbar navbar-expand-lg navbar-custom fixed-top">
         <div class="container-fluid">
-            <a class="navbar-brand" href="/menu">
+            <a class="navbar-brand" href="/inventory">
                 <i class="bi bi-box-seam"></i> 商品在庫管理システム
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
@@ -125,14 +128,14 @@
                             <table class="table table-hover align-middle">
                                 <thead class="table-light">
                                     <tr>
-                                        <th style="width: 10%;">商品ID</th>
-                                        <th style="width: 20%;">商品名</th>
-                                        <th style="width: 15%;">カテゴリ</th>
-                                        <th style="width: 10%;">価格</th>
-                                        <th style="width: 10%;">在庫数</th>
-                                        <th style="width: 12%;">ステータス</th>
-                                        <th style="width: 13%;">更新日</th>
-                                        <th style="width: 10%;">詳細</th>
+                                        <th class="w-10">商品ID</th>
+                                        <th class="w-20">商品名</th>
+                                        <th class="w-15">カテゴリ</th>
+                                        <th class="w-10">価格</th>
+                                        <th class="w-10">在庫数</th>
+                                        <th class="w-12">ステータス</th>
+                                        <th class="w-13">更新日</th>
+                                        <th class="w-10">詳細</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -150,17 +153,14 @@
                                         </td>
                                         <td>¥<span th:text="${#numbers.formatInteger(product.price, 0, 'COMMA')}">0</span></td>
                                         <td>
-                                            <!-- 在庫切れ・在庫不足の場合はリンク表示 -->
-                                            <a th:if="${product.stock <= 20}" 
-                                               href="javascript:void(0);" 
+                                            <!-- 在庫数をクリックすると入庫・出庫モーダルを表示 -->
+                                            <a href="javascript:void(0);" 
                                                data-bs-toggle="modal" 
                                                data-bs-target="#stockModal" 
-                                               class="text-decoration-underline"
-                                               th:text="${product.stock}">0</a>
-                                            <!-- 在庫十分の場合は通常テキスト -->
-                                            <span th:if="${product.stock > 20}" 
-                                                  class="stock-ok"
-                                                  th:text="${product.stock}">21</span>
+                                               class="text-decoration-underline stock-link"
+                                               th:attr="data-product-id=${product.id}, data-product-name=${product.productName}, data-current-stock=${product.stock}"
+                                               th:text="${product.stock}"
+                                               onclick="event.stopPropagation();">0</a>
                                         </td>
                                         <td>
                                             <span th:class="${'badge badge-status-' + product.status}"
@@ -257,6 +257,8 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
+            <!-- メッセージ表示エリア -->
+            <div id="stockModalMessage" class="alert d-none" role="alert"></div>
             <!-- 入庫・出庫選択ラジオボタン -->
             <div class="mb-3">
               <label class="form-label">操作を選択</label>
@@ -274,7 +276,7 @@
             <!-- 在庫数入力 -->
             <div class="mb-3">
               <label for="stockInput" class="form-label">在庫数を入力</label>
-              <input type="number" class="form-control" id="stockInput" placeholder="在庫数">
+              <input type="number" class="form-control" id="stockInput" placeholder="在庫数" min="1" required>
             </div>
           </div>
           <div class="modal-footer">
@@ -300,7 +302,7 @@
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
-            <form action="/logout" method="post" style="display: inline;">
+            <form action="/logout" method="post" class="form-inline">
               <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
               <button type="submit" class="btn btn-danger">
                 <i class="bi bi-box-arrow-right"></i> ログアウト
@@ -316,5 +318,8 @@
     
     <!-- カスタムJavaScript -->
     <script src="/js/common.js"></script>
+    
+    <!-- 在庫管理画面用JavaScript -->
+    <script src="/js/inventory.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ログイン - 商品在庫管理システム</title>
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" 
           rel="stylesheet" 

--- a/src/test/java/com/inventory/inventory_management/repository/StockTransactionRepositoryTest.java
+++ b/src/test/java/com/inventory/inventory_management/repository/StockTransactionRepositoryTest.java
@@ -1,0 +1,418 @@
+package com.inventory.inventory_management.repository;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.inventory.inventory_management.entity.Product;
+import com.inventory.inventory_management.entity.StockTransaction;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * StockTransactionRepositoryの統合テスト
+ * @SpringBootTestを使用したリポジトリ層のテスト
+ */
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@DisplayName("StockTransactionRepository 統合テスト")
+class StockTransactionRepositoryTest {
+
+    @Autowired
+    private StockTransactionRepository stockTransactionRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    private Integer testProduct1Id;
+    private Integer testProduct2Id;
+    private StockTransaction transaction1;
+    private StockTransaction transaction2;
+    private StockTransaction transaction3;
+
+    /**
+     * 各テストメソッド実行前の初期化処理
+     */
+    @BeforeEach
+    void setUp() {
+        // テストデータをクリア
+        stockTransactionRepository.deleteAll();
+        productRepository.deleteAll();
+
+        // テスト商品を作成
+        Product product1 = new Product();
+        product1.setProductCode("TEST0001");
+        product1.setProductName("テスト商品1");
+        product1.setCategory("Electronics");
+        product1.setPrice(new BigDecimal("10000.00"));
+        product1.setStock(50);
+        product1.setStatus("active");
+        product1.setCreatedAt(LocalDateTime.now());
+        product1.setUpdatedAt(LocalDateTime.now());
+        Product savedProduct1 = productRepository.save(product1);
+        testProduct1Id = savedProduct1.getId();
+
+        Product product2 = new Product();
+        product2.setProductCode("TEST0002");
+        product2.setProductName("テスト商品2");
+        product2.setCategory("Electronics");
+        product2.setPrice(new BigDecimal("20000.00"));
+        product2.setStock(30);
+        product2.setStatus("active");
+        product2.setCreatedAt(LocalDateTime.now());
+        product2.setUpdatedAt(LocalDateTime.now());
+        Product savedProduct2 = productRepository.save(product2);
+        testProduct2Id = savedProduct2.getId();
+
+        // テスト在庫変動履歴1: 入庫
+        transaction1 = new StockTransaction();
+        transaction1.setProductId(testProduct1Id);
+        transaction1.setTransactionType("in");
+        transaction1.setQuantity(10);
+        transaction1.setBeforeStock(50);
+        transaction1.setAfterStock(60);
+        transaction1.setUserId("testuser1");
+        transaction1.setTransactionDate(LocalDateTime.now().minusDays(2));
+        transaction1.setRemarks("テスト入庫1");
+        stockTransactionRepository.save(transaction1);
+
+        // テスト在庫変動履歴2: 出庫
+        transaction2 = new StockTransaction();
+        transaction2.setProductId(testProduct1Id);
+        transaction2.setTransactionType("out");
+        transaction2.setQuantity(5);
+        transaction2.setBeforeStock(60);
+        transaction2.setAfterStock(55);
+        transaction2.setUserId("testuser1");
+        transaction2.setTransactionDate(LocalDateTime.now().minusDays(1));
+        transaction2.setRemarks("テスト出庫");
+        stockTransactionRepository.save(transaction2);
+
+        // テスト在庫変動履歴3: 別商品の入庫
+        transaction3 = new StockTransaction();
+        transaction3.setProductId(testProduct2Id);
+        transaction3.setTransactionType("in");
+        transaction3.setQuantity(20);
+        transaction3.setBeforeStock(0);
+        transaction3.setAfterStock(20);
+        transaction3.setUserId("testuser2");
+        transaction3.setTransactionDate(LocalDateTime.now());
+        transaction3.setRemarks("テスト入庫2");
+        stockTransactionRepository.save(transaction3);
+    }
+
+    /**
+     * 商品IDで在庫変動履歴を取得できることを検証
+     */
+    @Test
+    @DisplayName("商品IDで在庫変動履歴を取得できる")
+    void findByProductIdOrderByTransactionDateDesc_Success() {
+        // When: 商品ID=testProduct1Idの履歴を取得
+        List<StockTransaction> transactions = stockTransactionRepository
+                .findByProductIdOrderByTransactionDateDesc(testProduct1Id);
+
+        // Then: 2件取得でき、日時降順でソートされている
+        assertNotNull(transactions);
+        assertEquals(2, transactions.size());
+        assertEquals("out", transactions.get(0).getTransactionType()); // 最新が先頭
+        assertEquals("in", transactions.get(1).getTransactionType());
+        assertTrue(transactions.get(0).getTransactionDate()
+                .isAfter(transactions.get(1).getTransactionDate()));
+        
+        // remarksフィールドが正しく取得される
+        assertEquals("テスト出庫", transactions.get(0).getRemarks());
+        assertEquals("テスト入庫1", transactions.get(1).getRemarks());
+    }
+
+    /**
+     * 存在しない商品IDで検索した場合、空リストが返されることを検証
+     */
+    @Test
+    @DisplayName("存在しない商品IDで検索すると空リストが返される")
+    void findByProductIdOrderByTransactionDateDesc_NotFound() {
+        // When: 存在しない商品IDで検索
+        List<StockTransaction> transactions = stockTransactionRepository
+                .findByProductIdOrderByTransactionDateDesc(999);
+
+        // Then: 空リストが返される
+        assertNotNull(transactions);
+        assertTrue(transactions.isEmpty());
+    }
+
+    /**
+     * 商品IDと取引種別で在庫変動履歴を取得できることを検証
+     */
+    @Test
+    @DisplayName("商品IDと取引種別で在庫変動履歴を取得できる")
+    void findByProductIdAndTransactionType_Success() {
+        // When: 商品ID=testProduct1Id、取引種別=inで検索
+        List<StockTransaction> transactions = stockTransactionRepository
+                .findByProductIdAndTransactionType(testProduct1Id, "in");
+
+        // Then: 1件取得できる
+        assertNotNull(transactions);
+        assertEquals(1, transactions.size());
+        assertEquals("in", transactions.get(0).getTransactionType());
+        assertEquals(10, transactions.get(0).getQuantity());
+    }
+
+    /**
+     * 商品IDと取引種別（出庫）で在庫変動履歴を取得できることを検証
+     */
+    @Test
+    @DisplayName("商品IDと取引種別（出庫）で在庫変動履歴を取得できる")
+    void findByProductIdAndTransactionType_Out_Success() {
+        // When: 商品ID=testProduct1Id、取引種別=outで検索
+        List<StockTransaction> transactions = stockTransactionRepository
+                .findByProductIdAndTransactionType(testProduct1Id, "out");
+
+        // Then: 1件取得できる
+        assertNotNull(transactions);
+        assertEquals(1, transactions.size());
+        assertEquals("out", transactions.get(0).getTransactionType());
+        assertEquals(5, transactions.get(0).getQuantity());
+    }
+
+    /**
+     * 該当する取引種別が存在しない場合、空リストが返されることを検証
+     */
+    @Test
+    @DisplayName("該当する取引種別が存在しない場合、空リストが返される")
+    void findByProductIdAndTransactionType_NotFound() {
+        // When: 商品ID=testProduct2Id、取引種別=outで検索（存在しない）
+        List<StockTransaction> transactions = stockTransactionRepository
+                .findByProductIdAndTransactionType(testProduct2Id, "out");
+
+        // Then: 空リストが返される
+        assertNotNull(transactions);
+        assertTrue(transactions.isEmpty());
+    }
+
+    /**
+     * 在庫変動履歴を保存できることを検証
+     */
+    @Test
+    @DisplayName("在庫変動履歴を保存できる")
+    void save_Success() {
+        // Given: 新しい商品を作成
+        Product product3 = new Product();
+        product3.setProductCode("TEST0003");
+        product3.setProductName("テスト商品3");
+        product3.setCategory("Electronics");
+        product3.setPrice(new BigDecimal("30000.00"));
+        product3.setStock(0);
+        product3.setStatus("active");
+        product3.setCreatedAt(LocalDateTime.now());
+        product3.setUpdatedAt(LocalDateTime.now());
+        Product savedProduct3 = productRepository.save(product3);
+        
+        // Given: 新しい在庫変動履歴
+        StockTransaction newTransaction = new StockTransaction();
+        newTransaction.setProductId(savedProduct3.getId());
+        newTransaction.setTransactionType("in");
+        newTransaction.setQuantity(100);
+        newTransaction.setBeforeStock(0);
+        newTransaction.setAfterStock(100);
+        newTransaction.setUserId("testuser3");
+        newTransaction.setTransactionDate(LocalDateTime.now());
+        newTransaction.setRemarks("新規入庫");
+
+        // When: 保存
+        StockTransaction saved = stockTransactionRepository.save(newTransaction);
+
+        // Then: 保存され、IDが付与される
+        assertNotNull(saved);
+        assertNotNull(saved.getId());
+        assertEquals(savedProduct3.getId(), saved.getProductId());
+        assertEquals("in", saved.getTransactionType());
+        assertEquals(100, saved.getQuantity());
+    }
+
+    /**
+     * 在庫変動履歴をすべて取得できることを検証
+     */
+    @Test
+    @DisplayName("在庫変動履歴をすべて取得できる")
+    void findAll_Success() {
+        // When: すべての履歴を取得
+        List<StockTransaction> transactions = stockTransactionRepository.findAll();
+
+        // Then: 3件取得できる
+        assertNotNull(transactions);
+        assertEquals(3, transactions.size());
+    }
+
+    /**
+     * 在庫変動履歴を削除できることを検証
+     */
+    @Test
+    @DisplayName("在庫変動履歴を削除できる")
+    void delete_Success() {
+        // Given: 削除する履歴のID
+        Integer idToDelete = transaction1.getId();
+
+        // When: 削除
+        stockTransactionRepository.deleteById(idToDelete);
+
+        // Then: 削除される
+        List<StockTransaction> transactions = stockTransactionRepository
+                .findByProductIdOrderByTransactionDateDesc(testProduct1Id);
+        assertEquals(1, transactions.size()); // 2件から1件に減る
+    }
+
+    /**
+     * 在庫変動履歴の件数を取得できることを検証
+     */
+    @Test
+    @DisplayName("在庫変動履歴の件数を取得できる")
+    void count_Success() {
+        // When: 件数を取得
+        long count = stockTransactionRepository.count();
+
+        // Then: 3件
+        assertEquals(3, count);
+    }
+
+    /**
+     * remarks=nullの在庫変動履歴を保存・取得できることを検証
+     */
+    @Test
+    @DisplayName("remarks=nullの在庫変動履歴を保存・取得できる")
+    void save_WithNullRemarks_Success() {
+        // Given: 新しい商品を作成
+        Product product4 = new Product();
+        product4.setProductCode("TEST0004");
+        product4.setProductName("テスト商品4");
+        product4.setCategory("Electronics");
+        product4.setPrice(new BigDecimal("40000.00"));
+        product4.setStock(0);
+        product4.setStatus("active");
+        product4.setCreatedAt(LocalDateTime.now());
+        product4.setUpdatedAt(LocalDateTime.now());
+        Product savedProduct4 = productRepository.save(product4);
+        
+        // Given: remarks=nullの在庫変動履歴
+        StockTransaction newTransaction = new StockTransaction();
+        newTransaction.setProductId(savedProduct4.getId());
+        newTransaction.setTransactionType("in");
+        newTransaction.setQuantity(50);
+        newTransaction.setBeforeStock(0);
+        newTransaction.setAfterStock(50);
+        newTransaction.setUserId("testuser4");
+        newTransaction.setTransactionDate(LocalDateTime.now());
+        newTransaction.setRemarks(null); // remarks=null
+
+        // When: 保存
+        StockTransaction saved = stockTransactionRepository.save(newTransaction);
+
+        // Then: 保存され、remarks=nullで取得できる
+        assertNotNull(saved);
+        assertNotNull(saved.getId());
+        assertNull(saved.getRemarks());
+
+        // データベースから再取得して確認
+        List<StockTransaction> transactions = stockTransactionRepository
+                .findByProductIdOrderByTransactionDateDesc(savedProduct4.getId());
+        assertEquals(1, transactions.size());
+        assertNull(transactions.get(0).getRemarks());
+    }
+
+    /**
+     * remarks=空文字の在庫変動履歴を保存・取得できることを検証
+     */
+    @Test
+    @DisplayName("remarks=空文字の在庫変動履歴を保存・取得できる")
+    void save_WithEmptyRemarks_Success() {
+        // Given: 新しい商品を作成
+        Product product5 = new Product();
+        product5.setProductCode("TEST0005");
+        product5.setProductName("テスト商品5");
+        product5.setCategory("Electronics");
+        product5.setPrice(new BigDecimal("50000.00"));
+        product5.setStock(0);
+        product5.setStatus("active");
+        product5.setCreatedAt(LocalDateTime.now());
+        product5.setUpdatedAt(LocalDateTime.now());
+        Product savedProduct5 = productRepository.save(product5);
+        
+        // Given: remarks=""の在庫変動履歴
+        StockTransaction newTransaction = new StockTransaction();
+        newTransaction.setProductId(savedProduct5.getId());
+        newTransaction.setTransactionType("out");
+        newTransaction.setQuantity(10);
+        newTransaction.setBeforeStock(100);
+        newTransaction.setAfterStock(90);
+        newTransaction.setUserId("testuser5");
+        newTransaction.setTransactionDate(LocalDateTime.now());
+        newTransaction.setRemarks(""); // remarks=空文字
+
+        // When: 保存
+        StockTransaction saved = stockTransactionRepository.save(newTransaction);
+
+        // Then: 保存され、remarks=""で取得できる
+        assertNotNull(saved);
+        assertNotNull(saved.getId());
+        assertEquals("", saved.getRemarks());
+
+        // データベースから再取得して確認
+        List<StockTransaction> transactions = stockTransactionRepository
+                .findByProductIdOrderByTransactionDateDesc(savedProduct5.getId());
+        assertEquals(1, transactions.size());
+        assertEquals("", transactions.get(0).getRemarks());
+    }
+
+    /**
+     * 長いremarksを保存・取得できることを検証
+     */
+    @Test
+    @DisplayName("長いremarksを保存・取得できる")
+    void save_WithLongRemarks_Success() {
+        // Given: 新しい商品を作成
+        Product product6 = new Product();
+        product6.setProductCode("TEST0006");
+        product6.setProductName("テスト商品6");
+        product6.setCategory("Electronics");
+        product6.setPrice(new BigDecimal("60000.00"));
+        product6.setStock(0);
+        product6.setStatus("active");
+        product6.setCreatedAt(LocalDateTime.now());
+        product6.setUpdatedAt(LocalDateTime.now());
+        Product savedProduct6 = productRepository.save(product6);
+        
+        // Given: 長いremarksの在庫変動履歴（255文字）
+        String longRemarks = "A".repeat(255);
+        StockTransaction newTransaction = new StockTransaction();
+        newTransaction.setProductId(savedProduct6.getId());
+        newTransaction.setTransactionType("in");
+        newTransaction.setQuantity(100);
+        newTransaction.setBeforeStock(0);
+        newTransaction.setAfterStock(100);
+        newTransaction.setUserId("testuser6");
+        newTransaction.setTransactionDate(LocalDateTime.now());
+        newTransaction.setRemarks(longRemarks);
+
+        // When: 保存
+        StockTransaction saved = stockTransactionRepository.save(newTransaction);
+
+        // Then: 保存され、長いremarksで取得できる
+        assertNotNull(saved);
+        assertNotNull(saved.getId());
+        assertEquals(255, saved.getRemarks().length());
+        assertEquals(longRemarks, saved.getRemarks());
+
+        // データベースから再取得して確認
+        List<StockTransaction> transactions = stockTransactionRepository
+                .findByProductIdOrderByTransactionDateDesc(savedProduct6.getId());
+        assertEquals(1, transactions.size());
+        assertEquals(longRemarks, transactions.get(0).getRemarks());
+    }
+}

--- a/src/test/resources/data-test.sql
+++ b/src/test/resources/data-test.sql
@@ -26,3 +26,17 @@ INSERT INTO system_settings (setting_key, setting_value, description, data_type)
 ('stock_critical_threshold', '0', '在庫切れ閾値', 'INTEGER'),
 ('session_timeout_minutes', '30', 'セッションタイムアウト（分）', 'INTEGER'),
 ('max_login_attempts', '5', '最大ログイン試行回数', 'INTEGER');
+
+-- テスト用商品データ
+INSERT INTO products (id, product_code, product_name, category, sku, price, stock, status, description) VALUES
+(1, 'P0000001', 'テスト商品A', 'Electronics', 'SKU-TEST-001', 1000.00, 50, 'active', 'テスト用の商品A'),
+(2, 'P0000002', 'テスト商品B', 'Clothing', 'SKU-TEST-002', 2000.00, 30, 'active', 'テスト用の商品B'),
+(3, 'P0000003', 'テスト商品C', 'Food', 'SKU-TEST-003', 500.00, 10, 'active', 'テスト用の商品C'),
+(4, 'P0000004', 'テスト商品D', 'Books', 'SKU-TEST-004', 1500.00, 0, 'active', 'テスト用の商品D（在庫切れ）');
+
+-- テスト用在庫履歴データ（remarksカラムを含む）
+INSERT INTO stock_transactions (product_id, transaction_type, quantity, before_stock, after_stock, user_id, transaction_date, remarks) VALUES
+(1, 'in', 50, 0, 50, 'testuser', CURRENT_TIMESTAMP, '初期在庫入庫'),
+(2, 'in', 30, 0, 30, 'testuser', CURRENT_TIMESTAMP, '初期在庫入庫'),
+(3, 'in', 20, 0, 20, 'adminuser', CURRENT_TIMESTAMP, '初期在庫入庫'),
+(3, 'out', 10, 20, 10, 'adminuser', CURRENT_TIMESTAMP, 'テスト出庫処理');

--- a/src/test/resources/schema-test.sql
+++ b/src/test/resources/schema-test.sql
@@ -61,16 +61,18 @@ CREATE TABLE IF NOT EXISTS products (
 CREATE TABLE IF NOT EXISTS stock_transactions (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     product_id INT NOT NULL,
-    transaction_type VARCHAR(20) NOT NULL,
+    transaction_type VARCHAR(10) NOT NULL,
     quantity INTEGER NOT NULL,
     before_stock INTEGER NOT NULL,
     after_stock INTEGER NOT NULL,
-    user_id INT NOT NULL,
-    user_name VARCHAR(100) NOT NULL,
-    note VARCHAR(255) NULL,
+    user_id VARCHAR(50) NOT NULL,
     transaction_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    remarks VARCHAR(255) NULL,
     FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT ON UPDATE CASCADE,
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT ON UPDATE CASCADE
+    CHECK (transaction_type IN ('in', 'out')),
+    CHECK (quantity > 0),
+    CHECK (before_stock >= 0),
+    CHECK (after_stock >= 0)
 );
 
 -- システム設定テーブル

--- a/update_stock.sql
+++ b/update_stock.sql
@@ -1,0 +1,33 @@
+-- 30アイテムの在庫を0に更新
+-- そのうち10アイテムを販売中止に設定
+
+-- 30アイテムすべての在庫を0に更新
+UPDATE products SET stock = 0, updated_at = NOW()
+WHERE product_code IN (
+    '93TGNAY7', 'TYYZ5AV7', '5C94FGTQ', 'XBHKYPQB', '728GCZFU',
+    '27R9M103', 'JDOVOMY2', '0KHFMXFN', 'T4F2EW7G', 'GL199BEL',
+    'SX7HALUU', '1AOXE5QW', 'KOXR70B4', 'X2D1GWO5', 'ZKI2USNA',
+    'EPKS7ECS', 'UB8UO1PA', '6ID782KK', 'YWJW03Z5', '44WFTM8R',
+    'CVYLYMJ3', '9UQRU4ZU', '4RBD28EN', 'XNTCQGCN', 'T27XMDD2',
+    'OR97MBZ1', 'HGFIOVL2', '758FMQ42', '8XJVYL79', 'YWS54ZGS'
+);
+
+-- 最初の10アイテムを販売中止に変更
+UPDATE products SET status = 'inactive', updated_at = NOW()
+WHERE product_code IN (
+    '93TGNAY7', 'TYYZ5AV7', '5C94FGTQ', 'XBHKYPQB', '728GCZFU',
+    '27R9M103', 'JDOVOMY2', '0KHFMXFN', 'T4F2EW7G', 'GL199BEL'
+);
+
+-- 確認用クエリ
+SELECT product_code, product_name, stock, status 
+FROM products 
+WHERE product_code IN (
+    '93TGNAY7', 'TYYZ5AV7', '5C94FGTQ', 'XBHKYPQB', '728GCZFU',
+    '27R9M103', 'JDOVOMY2', '0KHFMXFN', 'T4F2EW7G', 'GL199BEL',
+    'SX7HALUU', '1AOXE5QW', 'KOXR70B4', 'X2D1GWO5', 'ZKI2USNA',
+    'EPKS7ECS', 'UB8UO1PA', '6ID782KK', 'YWJW03Z5', '44WFTM8R',
+    'CVYLYMJ3', '9UQRU4ZU', '4RBD28EN', 'XNTCQGCN', 'T27XMDD2',
+    'OR97MBZ1', 'HGFIOVL2', '758FMQ42', '8XJVYL79', 'YWS54ZGS'
+)
+ORDER BY product_code;


### PR DESCRIPTION
- 在庫入庫・出庫モーダル処理作成
- StockTransactionエンティティにremarks（備考）フィールドを追加
- stock_transactionsテーブルにremarks VARCHAR(255)カラムを追加
- user_idをVARCHAR(50)型に変更し外部キー制約を削除
- 不要なuser_nameとnoteカラムを削除しスキーマを整理
- テスト環境スキーマとテストデータを更新

close #33 