### PR TITLE
商品管理画面に削除済み商品フィルタ機能を追加、UI統一、テスト強化

### DIFF
--- a/Doc/git_readMe.txt
+++ b/Doc/git_readMe.txt
@@ -62,6 +62,12 @@ git checkout -b feature/other
 ##開発ブランチ 在庫(管理者)
 git checkout -b feature/AdminInventory
 
+##開発ブランチ 商品(管理者)
+git checkout -b feature/product
+
+##開発ブランチ 在庫(管理者)
+git checkout -b feature/AdminUsers
+
 ーーーーーーーーーーーーー
 ##作成しながら、ブランチ切り替え
 git checkout -b requirements-definition-1
@@ -76,45 +82,6 @@ git branch
 git push -u origin requirements-definition-1
 
 --------------------------------------------
-mainへマージあとに、ローカルリポジトリを最新にするには
-##mainブランチへ切り替え
-git checkout main
-
-##リモートリポジトリの最新情報を取得（originはリモートの最新:git remote -v で確認できる）
-git fetch origin
-
-##リモートの main をローカルの main にマージ
-##リモート追跡ブランチ（origin/main）の最新状態をローカルの main ブランチにマージします。
-git merge origin/main
-
-以上で最新化が可能です。
-コンフリクトが起きると、マージできないです。
-ローカルのみのファイルは消されないが、一時退避「git stash」やローカルコミット「git add とgit commit」をしておくとよい
-　　　　↓　以下がstushありの例
-ーーーーーーーーーーーーーーーーーーーーーーーーーー
-#ローカルファイルの保持
-# 1. 現在の変更を一時退避
-git stash
-
-# 2. mainブランチへ切り替え
-git checkout main
-
-# 3. リモートリポジトリの最新情報を取得
-git fetch origin
-
-# 4. リモートの main をローカルの main にマージ
-git merge origin/main
-
-# 5. 一時退避した変更を戻す
-git stash pop
-
---------
-補足
-・git stash list を実行して、スタッシュがまだ存在しているか確認できます。
-・git stash drop で手動で削除できます
-・git stash clear ですべてのスタッシュを削除ができます
-
-ーーーーーーーーーーーーーーーーーーーーーーーーーー
 #ローカルブランチの削除手順
 ##現在のブランチを確認
 #削除対象のブランチでないことを確認する
@@ -139,18 +106,39 @@ git branch -D requirements-definition-1
 git branch -D requirements-definition-2
 
 ーーーーーーーーーーーーーーーーーーーーーーーーーー
+mainへマージあとに、ローカルリポジトリを最新にするには
+##mainブランチへ切り替え
+git checkout main
+
+##リモートリポジトリの最新情報を取得（originはリモートの最新:git remote -v で確認できる）
+git fetch origin
+
+##リモートの main をローカルの main にマージ
+##リモート追跡ブランチ（origin/main）の最新状態をローカルの main ブランチにマージします。
+git merge origin/main
+
+以上で最新化が可能です。
+コンフリクトが起きると、マージできないです。
+ローカルのみのファイルは消されないが、一時退避「git stash」やローカルコミット「git add とgit commit」をしておくとよい
+　　　　↓　以下がstushありの例
+ーーーーーーーーーーーーーーーーーーーーーーーーーー
 #ローカルファイルの保持
-1.現在の変更を確認
+# 1. 現在の変更を確認
 git status
 
-2.変更を一時退避（必要に応じて）
+# 2. 現在の変更を一時退避
 git stash
-これにより、ローカルの変更を一時的に保存できます。
 
-3.ブランチを作成して切り替え
-git checkout -b system-design-view-user origin/system-design-view-user
+# 3. mainブランチへ切り替え
+git checkout main
 
-4.退避した変更を戻す（必要に応じて）
+# 4. リモートリポジトリの最新情報を取得
+git fetch origin
+
+# 5. リモートの main をローカルの main にマージ
+git merge origin/main
+
+# 6. 一時退避した変更を戻す
 git stash pop
 
 --------
@@ -158,17 +146,6 @@ git stash pop
 ・git stash list を実行して、スタッシュがまだ存在しているか確認できます。
 ・git stash drop で手動で削除できます
 ・git stash clear ですべてのスタッシュを削除ができます
-
-ーーーーーーーーーーーーーーーーーーーーーーーーーー
-ローカル環境にマージするには
-1.取り込み
-git fetch
-
-2.main ブランチに切り替え
-git checkout main
-
-3.リモートの main をローカルの main にマージ
-git merge origin/main
 
 ーーーーーーーーーーーーーーーーーーーーーーーーーー
 ブランチ内容がすべて取り込まれているかの確認
@@ -188,7 +165,7 @@ git log main..feature/inventory
 git fetch --prune
 リモートリポジトリの最新状態を取得し、ローカルで追跡している削除済みのリモートブランチを整理します。
 
-git branch -vv:
+git branch -vv
 ローカルブランチとリモートブランチの対応状況を表示します。
 gone と表示されるブランチは、リモートで削除されているがローカルに残っているものです。
 

--- a/src/main/java/com/inventory/inventory_management/controller/AdminInventoryController.java
+++ b/src/main/java/com/inventory/inventory_management/controller/AdminInventoryController.java
@@ -145,6 +145,8 @@ public class AdminInventoryController {
             // モデルに追加
             model.addAttribute("product", product);
             model.addAttribute("transactions", transactions);
+            // 遷移元パラメータをテンプレートで使用するために追加
+            model.addAttribute("from", from);
             // 戻り先（パンくずなど）を設定
             if (from != null && from.equals("products")) {
                 model.addAttribute("parentLabel", "商品管理");

--- a/src/main/java/com/inventory/inventory_management/controller/AdminProductController.java
+++ b/src/main/java/com/inventory/inventory_management/controller/AdminProductController.java
@@ -61,7 +61,8 @@ public class AdminProductController {
                     criteria.getCategory(),
                     criteria.getStatus(),
                     criteria.getSort(),
-                    criteria.getPage());
+                    criteria.getPage(),
+                    criteria.isIncludeDeleted());
 
             List<String> categories = adminProductService.getAllCategories();
 
@@ -73,6 +74,7 @@ public class AdminProductController {
             model.addAttribute("products",            productPage.getContent());
             model.addAttribute("categories",          categories);
             model.addAttribute("criteria",            criteria);
+            model.addAttribute("includeDeleted",      criteria.isIncludeDeleted());
             model.addAttribute("currentPage",         criteria.getPage());
             model.addAttribute("totalPages",          productPage.getTotalPages());
             model.addAttribute("totalElements",       productPage.getTotalElements());
@@ -114,6 +116,7 @@ public class AdminProductController {
         if (!model.containsAttribute("detailForm")) {
             model.addAttribute("detailForm", new ProductDetailForm());
         }
+        model.addAttribute("categories", adminProductService.getAllCategories());
         return "admin/product-create";
     }
 

--- a/src/main/java/com/inventory/inventory_management/dto/request/ProductSearchCriteriaDto.java
+++ b/src/main/java/com/inventory/inventory_management/dto/request/ProductSearchCriteriaDto.java
@@ -26,4 +26,7 @@ public class ProductSearchCriteriaDto {
 
     /** ページ番号（0始まり） */
     private int page = 0;
+
+    /** 削除済み商品を含めるかどうか */
+    private boolean includeDeleted = false;
 }

--- a/src/main/java/com/inventory/inventory_management/service/AdminProductService.java
+++ b/src/main/java/com/inventory/inventory_management/service/AdminProductService.java
@@ -43,13 +43,14 @@ public class AdminProductService {
     // =========================================================
 
     /**
-     * 商品を検索（削除済み除外・ページング対応）
+     * 商品を検索（削除済み除外または含む・ページング対応）
      *
-     * @param keyword  商品名キーワード（部分一致）
-     * @param category カテゴリフィルター
-     * @param status   ステータスフィルター（active / inactive）
-     * @param sortBy   ソート順（name / name_desc / price / price_desc / stock / stock_desc / updated）
-     * @param page     ページ番号（0始まり）
+     * @param keyword        商品名キーワード（部分一致）
+     * @param category       カテゴリフィルター
+     * @param status         ステータスフィルター（active / inactive）
+     * @param sortBy         ソート順（name / name_desc / price / price_desc / stock / stock_desc / updated）
+     * @param page           ページ番号（0始まり）
+     * @param includeDeleted 削除済み商品を含めるかどうか
      * @return 検索結果ページ
      */
     public Page<Product> searchProducts(
@@ -57,14 +58,19 @@ public class AdminProductService {
             String category,
             String status,
             String sortBy,
-            int page) {
+            int page,
+            boolean includeDeleted) {
 
         Sort sort = createSort(sortBy);
         Pageable pageable = PageRequest.of(page, pageSize, sort);
 
-        log.debug("商品検索: keyword={}, category={}, status={}, sort={}, page={}",
-                keyword, category, status, sortBy, page);
+        log.debug("商品検索: keyword={}, category={}, status={}, sort={}, page={}, includeDeleted={}",
+                keyword, category, status, sortBy, page, includeDeleted);
 
+        if (includeDeleted) {
+            return productRepository.findBySearchConditionsIncludingDeleted(
+                    keyword, category, status, null, null, pageable);
+        }
         return productRepository.findBySearchConditions(keyword, category, status, pageable);
     }
 

--- a/src/main/resources/static/js/admin-common.js
+++ b/src/main/resources/static/js/admin-common.js
@@ -1,8 +1,4 @@
 // 管理者専用の初期化処理
 console.log('Admin common JS loaded');
 
-// 削除モーダルの初期化
-const deleteModalElement = document.getElementById('deleteModal');
-if (deleteModalElement) {
-    deleteModal = new bootstrap.Modal(deleteModalElement);
-}
+

--- a/src/main/resources/static/js/admin-products.js
+++ b/src/main/resources/static/js/admin-products.js
@@ -3,21 +3,34 @@
  * admin/products.html で使用
  */
 
-/**
- * 削除確認モーダルを開く
- * @param {HTMLElement} btn - data-product-id / data-product-name を持つボタン要素
- */
-function openDeleteModal(btn) {
-    const productId   = btn.getAttribute('data-product-id');
-    const productName = btn.getAttribute('data-product-name');
+/** 削除モーダルの Bootstrap インスタンス */
+let deleteModal = null;
 
-    // モーダル内の表示を更新
-    document.getElementById('deleteProductName').textContent = productName;
+document.addEventListener('DOMContentLoaded', function () {
 
-    // 削除フォームのアクションを動的に設定
-    document.getElementById('deleteForm').action = '/admin/products/' + productId + '/delete';
+    // 削除モーダル初期化
+    const deleteModalElement = document.getElementById('deleteModal');
+    if (deleteModalElement) {
+        deleteModal = bootstrap.Modal.getOrCreateInstance(deleteModalElement);
+    }
 
-    // モーダルを表示
-    const modal = new bootstrap.Modal(document.getElementById('deleteModal'));
-    modal.show();
-}
+    // 削除ボタン: イベントデリゲーション（.product-delete-trigger クラスを持つボタン）
+    document.querySelectorAll('.product-delete-trigger').forEach(function (trigger) {
+        trigger.addEventListener('click', function () {
+            const productId   = this.dataset.productId;
+            const productName = this.dataset.productName;
+
+            // モーダル内の表示を更新
+            document.getElementById('deleteProductName').textContent = productName;
+
+            // 削除フォームのアクションを動的に設定
+            document.getElementById('deleteForm').action = '/admin/products/' + productId + '/delete';
+
+            // モーダルを表示
+            if (deleteModal) {
+                deleteModal.show();
+            }
+        });
+    });
+
+});

--- a/src/main/resources/templates/admin/inventory-detail.html
+++ b/src/main/resources/templates/admin/inventory-detail.html
@@ -18,7 +18,7 @@
     <!-- ナビゲーションバー（管理者用） -->
     <nav class="navbar navbar-expand-lg navbar-custom-admin fixed-top">
         <div class="container-fluid">
-            <a class="navbar-brand" href="/admin/menu">
+            <a class="navbar-brand" href="/admin/inventory">
                 <i class="bi bi-shield-lock"></i> 商品在庫管理システム <span class="badge admin-badge">管理者</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
@@ -39,11 +39,6 @@
                     <li class="nav-item">
                         <a class="nav-link" href="/admin/users">
                             <i class="bi bi-people"></i> ユーザー管理
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/admin/menu">
-                            <i class="bi bi-house"></i> メニュー
                         </a>
                     </li>
                     <li class="nav-item">
@@ -277,7 +272,10 @@
 
                 <!-- アクションボタン -->
                 <div class="d-flex justify-content-between mb-4">
-                    <a href="/admin/inventory" class="btn btn-secondary">
+                    <a th:if="${from == 'products'}" href="/admin/products" class="btn btn-secondary">
+                        <i class="bi bi-arrow-left"></i> 商品管理に戻る
+                    </a>
+                    <a th:if="${from != 'products'}" href="/admin/inventory" class="btn btn-secondary">
                         <i class="bi bi-arrow-left"></i> 在庫管理に戻る
                     </a>
                 </div>

--- a/src/main/resources/templates/admin/inventory.html
+++ b/src/main/resources/templates/admin/inventory.html
@@ -42,11 +42,6 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/admin/menu">
-                            <i class="bi bi-house"></i> メニュー
-                        </a>
-                    </li>
-                    <li class="nav-item">
                         <form action="/logout" method="post" class="form-inline">
                             <button type="submit" class="btn btn-link nav-link btn-link-inline">
                                 <i class="bi bi-box-arrow-right"></i> ログアウト

--- a/src/main/resources/templates/admin/product-create.html
+++ b/src/main/resources/templates/admin/product-create.html
@@ -18,7 +18,7 @@
     <!-- ナビゲーションバー（管理者用） -->
     <nav class="navbar navbar-expand-lg navbar-custom-admin fixed-top">
         <div class="container-fluid">
-            <a class="navbar-brand" href="/admin/menu">
+            <a class="navbar-brand" href="/admin/inventory">
                 <i class="bi bi-shield-lock"></i> 商品在庫管理システム <span class="badge admin-badge">管理者</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
@@ -42,11 +42,6 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/admin/menu">
-                            <i class="bi bi-house"></i> メニュー
-                        </a>
-                    </li>
-                    <li class="nav-item">
                         <form th:action="@{/logout}" method="post" class="form-inline">
                             <button type="submit" class="btn btn-link nav-link btn-link-inline">
                                 <i class="bi bi-box-arrow-right"></i> ログアウト
@@ -65,7 +60,6 @@
                 <!-- パンくずリスト -->
                 <nav aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="/admin/menu">ホーム</a></li>
                         <li class="breadcrumb-item"><a href="/admin/products">商品管理</a></li>
                         <li class="breadcrumb-item active" aria-current="page">商品新規登録</li>
                     </ol>
@@ -106,7 +100,7 @@
                                         <label for="productName" class="form-label">商品名 <span class="text-danger">*</span></label>
                                         <input type="text" class="form-control" id="productName"
                                                th:field="*{productName}" placeholder="商品名を入力" required>
-                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('"'"'productName'"'"')}" th:errors="*{productName}"></div>
+                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('productName')}" th:errors="*{productName}"></div>
                                     </div>
                                 </div>
                                 <div class="col-md-6">
@@ -116,7 +110,7 @@
                                             <option value="">選択してください</option>
                                             <option th:each="cat : ${categories}" th:value="${cat}" th:text="${cat}"></option>
                                         </select>
-                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('"'"'category'"'"')}" th:errors="*{category}"></div>
+                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('category')}" th:errors="*{category}"></div>
                                     </div>
                                 </div>
                             </div>
@@ -126,7 +120,7 @@
                                         <label for="sku" class="form-label">SKU</label>
                                         <input type="text" class="form-control" id="sku"
                                                th:field="*{sku}" placeholder="SKU（任意）">
-                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('"'"'sku'"'"')}" th:errors="*{sku}"></div>
+                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('sku')}" th:errors="*{sku}"></div>
                                     </div>
                                 </div>
                                 <div class="col-md-3">
@@ -134,7 +128,7 @@
                                         <label for="price" class="form-label">価格（円） <span class="text-danger">*</span></label>
                                         <input type="number" class="form-control" id="price"
                                                th:field="*{price}" placeholder="価格を入力" min="0" step="0.01" required>
-                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('"'"'price'"'"')}" th:errors="*{price}"></div>
+                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('price')}" th:errors="*{price}"></div>
                                     </div>
                                 </div>
                                 <div class="col-md-3">
@@ -142,7 +136,7 @@
                                         <label for="stockQuantity" class="form-label">在庫数 <span class="text-danger">*</span></label>
                                         <input type="number" class="form-control" id="stockQuantity"
                                                th:field="*{stockQuantity}" placeholder="在庫数を入力" min="0" required>
-                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('"'"'stockQuantity'"'"')}" th:errors="*{stockQuantity}"></div>
+                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('stockQuantity')}" th:errors="*{stockQuantity}"></div>
                                     </div>
                                 </div>
                             </div>
@@ -170,7 +164,7 @@
                                 <label for="description" class="form-label">商品説明</label>
                                 <textarea class="form-control" id="description" th:field="*{description}"
                                           placeholder="商品の説明（任意）" rows="3"></textarea>
-                                <div class="invalid-feedback" th:if="${#fields.hasErrors('"'"'description'"'"')}" th:errors="*{description}"></div>
+                                <div class="invalid-feedback" th:if="${#fields.hasErrors('description')}" th:errors="*{description}"></div>
                             </div>
                             <div class="row">
                                 <div class="col-md-6">
@@ -178,7 +172,7 @@
                                         <label for="dimensions" class="form-label">寸法</label>
                                         <input type="text" class="form-control" id="dimensions"
                                                th:field="*{dimensions}" placeholder="例: 100x200x50mm">
-                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('"'"'dimensions'"'"')}" th:errors="*{dimensions}"></div>
+                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('dimensions')}" th:errors="*{dimensions}"></div>
                                     </div>
                                 </div>
                                 <div class="col-md-6">
@@ -186,7 +180,7 @@
                                         <label for="variations" class="form-label">バリエーション</label>
                                         <input type="text" class="form-control" id="variations"
                                                th:field="*{variations}" placeholder="例: 色、サイズなど">
-                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('"'"'variations'"'"')}" th:errors="*{variations}"></div>
+                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('variations')}" th:errors="*{variations}"></div>
                                     </div>
                                 </div>
                             </div>
@@ -196,7 +190,7 @@
                                         <label for="warrantyMonths" class="form-label">保証期間（月）</label>
                                         <input type="number" class="form-control" id="warrantyMonths"
                                                th:field="*{warrantyMonths}" placeholder="保証期間" min="0">
-                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('"'"'warrantyMonths'"'"')}" th:errors="*{warrantyMonths}"></div>
+                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('warrantyMonths')}" th:errors="*{warrantyMonths}"></div>
                                     </div>
                                 </div>
                                 <div class="col-md-4">
@@ -204,7 +198,7 @@
                                         <label for="manufacturingDate" class="form-label">製造日</label>
                                         <input type="date" class="form-control" id="manufacturingDate"
                                                th:field="*{manufacturingDate}">
-                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('"'"'manufacturingDate'"'"')}" th:errors="*{manufacturingDate}"></div>
+                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('manufacturingDate')}" th:errors="*{manufacturingDate}"></div>
                                     </div>
                                 </div>
                                 <div class="col-md-4">
@@ -212,7 +206,7 @@
                                         <label for="expirationDate" class="form-label">有効期限</label>
                                         <input type="date" class="form-control" id="expirationDate"
                                                th:field="*{expirationDate}">
-                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('"'"'expirationDate'"'"')}" th:errors="*{expirationDate}"></div>
+                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('expirationDate')}" th:errors="*{expirationDate}"></div>
                                     </div>
                                 </div>
                             </div>
@@ -220,7 +214,7 @@
                                 <label for="tags" class="form-label">タグ</label>
                                 <input type="text" class="form-control" id="tags"
                                        th:field="*{tags}" placeholder="カンマ区切りでタグを入力（例: 新製品, セール）">
-                                <div class="invalid-feedback" th:if="${#fields.hasErrors('"'"'tags'"'"')}" th:errors="*{tags}"></div>
+                                <div class="invalid-feedback" th:if="${#fields.hasErrors('tags')}" th:errors="*{tags}"></div>
                             </div>
                         </div>
                     </div>

--- a/src/main/resources/templates/admin/product-detail.html
+++ b/src/main/resources/templates/admin/product-detail.html
@@ -18,7 +18,7 @@
     <!-- ナビゲーションバー（管理者用） -->
     <nav class="navbar navbar-expand-lg navbar-custom-admin fixed-top">
         <div class="container-fluid">
-            <a class="navbar-brand" href="/admin/menu">
+            <a class="navbar-brand" href="/admin/inventory">
                 <i class="bi bi-shield-lock"></i> 商品在庫管理システム <span class="badge admin-badge">管理者</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
@@ -42,11 +42,6 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/admin/menu">
-                            <i class="bi bi-house"></i> メニュー
-                        </a>
-                    </li>
-                    <li class="nav-item">
                         <form action="/logout" method="post" class="form-inline">
                             <button type="submit" class="btn btn-link nav-link btn-link-inline">
                                 <i class="bi bi-box-arrow-right"></i> ログアウト
@@ -65,7 +60,6 @@
                 <!-- パンくずリスト -->
                 <nav aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="/admin/menu">ホーム</a></li>
                         <li class="breadcrumb-item"><a href="/admin/products">商品管理</a></li>
                         <li class="breadcrumb-item active" aria-current="page">商品詳細</li>
                     </ol>
@@ -278,7 +272,12 @@
 
                 <!-- アクションボタン -->
                 <div class="d-flex justify-content-between mb-4">
-                    <a href="/admin/inventory" class="btn btn-secondary">
+                    <!-- 商品管理から遷移した場合は商品管理へ戻る -->
+                    <a th:if="${from == 'products'}" href="/admin/products" class="btn btn-secondary">
+                        <i class="bi bi-arrow-left"></i> 商品管理に戻る
+                    </a>
+                    <!-- 在庫管理から遷移した場合（またはfromが無い場合）は在庫管理へ戻る -->
+                    <a th:if="${from != 'products'}" href="/admin/inventory" class="btn btn-secondary">
                         <i class="bi bi-arrow-left"></i> 在庫管理に戻る
                     </a>
                 </div>

--- a/src/main/resources/templates/admin/product-edit.html
+++ b/src/main/resources/templates/admin/product-edit.html
@@ -18,7 +18,7 @@
     <!-- ナビゲーションバー（管理者用） -->
     <nav class="navbar navbar-expand-lg navbar-custom-admin fixed-top">
         <div class="container-fluid">
-            <a class="navbar-brand" href="/admin/menu">
+            <a class="navbar-brand" href="/admin/inventory">
                 <i class="bi bi-shield-lock"></i> 商品在庫管理システム <span class="badge admin-badge">管理者</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
@@ -42,11 +42,6 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/admin/menu">
-                            <i class="bi bi-house"></i> メニュー
-                        </a>
-                    </li>
-                    <li class="nav-item">
                         <form th:action="@{/logout}" method="post" class="form-inline">
                             <button type="submit" class="btn btn-link nav-link btn-link-inline">
                                 <i class="bi bi-box-arrow-right"></i> ログアウト
@@ -65,7 +60,6 @@
                 <!-- パンくずリスト -->
                 <nav aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="/admin/menu">ホーム</a></li>
                         <li class="breadcrumb-item"><a href="/admin/products">商品管理</a></li>
                         <li class="breadcrumb-item active" aria-current="page">商品編集</li>
                     </ol>

--- a/src/main/resources/templates/admin/products.html
+++ b/src/main/resources/templates/admin/products.html
@@ -18,7 +18,7 @@
     <!-- ナビゲーションバー（管理者用） -->
     <nav class="navbar navbar-expand-lg navbar-custom-admin fixed-top">
         <div class="container-fluid">
-            <a class="navbar-brand" href="/admin/menu">
+            <a class="navbar-brand" href="/admin/inventory">
                 <i class="bi bi-shield-lock"></i> 商品在庫管理システム <span class="badge admin-badge">管理者</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
@@ -39,11 +39,6 @@
                     <li class="nav-item">
                         <a class="nav-link" href="/admin/users">
                             <i class="bi bi-people"></i> ユーザー管理
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/admin/menu">
-                            <i class="bi bi-house"></i> メニュー
                         </a>
                     </li>
                     <li class="nav-item">
@@ -83,7 +78,6 @@
                     <p class="mb-0">
                         この画面では、商品情報を1件ずつ入力・編集できます。
                         <strong>在庫数の確認や一括表示は<a href="/admin/inventory" class="alert-link">在庫管理画面</a></strong>をご利用ください。
-                        <strong>複数商品の一括登録は<a href="/admin/products/import" class="alert-link">CSVインポート</a></strong>をご利用ください。
                     </p>
                 </div>
 
@@ -138,22 +132,22 @@
                                     <option value="updated"    th:selected="${criteria.sort == 'updated'}">更新日（新しい順）</option>
                                 </select>
                             </div>
-                            <div class="col-md-1 d-flex align-items-end">
-                                <button type="submit" class="btn btn-primary w-100">
-                                    <i class="bi bi-search"></i>
-                                </button>
-                            </div>
+                            <div class="col-md-1"></div>
                         </div>
                         <div class="row mt-2">
-                            <div class="col-12">
-                                <a th:href="@{/admin/products}" class="btn btn-secondary btn-sm">
+                            <div class="col-12 col-md-11 pe-md-0 d-flex justify-content-end align-items-center">
+                                <div class="form-check me-3 mb-0">
+                                    <input class="form-check-input" type="checkbox" name="includeDeleted"
+                                           id="includeDeleted" th:checked="${includeDeleted}">
+                                    <label class="form-check-label" for="includeDeleted">
+                                        削除済み商品を含める
+                                    </label>
+                                </div>
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="bi bi-search"></i> 検索
+                                </button>
+                                <a th:href="@{/admin/products}" class="btn btn-secondary ms-2">
                                     <i class="bi bi-x-circle"></i> クリア
-                                </a>
-                                <a href="/admin/products/import" class="btn btn-outline-success btn-sm ms-2">
-                                    <i class="bi bi-upload"></i> CSV一括登録
-                                </a>
-                                <a href="/admin/products/export" class="btn btn-outline-primary btn-sm ms-2">
-                                    <i class="bi bi-download"></i> CSVエクスポート
                                 </a>
                             </div>
                         </div>
@@ -233,10 +227,10 @@
                                                 <i class="bi bi-pencil"></i>
                                             </a>
                                             <button th:if="${product.deletedAt == null}"
-                                                    class="btn btn-sm btn-outline-danger"
+                                                    type="button"
+                                                    class="btn btn-sm btn-outline-danger product-delete-trigger"
                                                     th:data-product-id="${product.id}"
                                                     th:data-product-name="${product.productName}"
-                                                    onclick="openDeleteModal(this)"
                                                     title="削除">
                                                 <i class="bi bi-trash"></i>
                                             </button>
@@ -259,14 +253,14 @@
                                 <!-- 最初のページ -->
                                 <li class="page-item" th:classappend="${currentPage == 0} ? 'disabled'">
                                     <a class="page-link"
-                                       th:href="@{/admin/products(search=${criteria.search}, category=${criteria.category}, status=${criteria.status}, sort=${criteria.sort}, page=0)}">
+                                       th:href="@{/admin/products(search=${criteria.search}, category=${criteria.category}, status=${criteria.status}, sort=${criteria.sort}, includeDeleted=${includeDeleted}, page=0)}">
                                         <i class="bi bi-chevron-double-left"></i>
                                     </a>
                                 </li>
                                 <!-- 前のページ -->
                                 <li class="page-item" th:classappend="${currentPage == 0} ? 'disabled'">
                                     <a class="page-link"
-                                       th:href="@{/admin/products(search=${criteria.search}, category=${criteria.category}, status=${criteria.status}, sort=${criteria.sort}, page=${currentPage - 1})}">
+                                       th:href="@{/admin/products(search=${criteria.search}, category=${criteria.category}, status=${criteria.status}, sort=${criteria.sort}, includeDeleted=${includeDeleted}, page=${currentPage - 1})}">
                                         <i class="bi bi-chevron-left"></i>
                                     </a>
                                 </li>
@@ -281,7 +275,7 @@
                                     <li th:if="${i != currentPage and (i < 3 or i > totalPages - 4 or (i >= currentPage - 2 and i <= currentPage + 2))}" 
                                         class="page-item">
                                         <a class="page-link"
-                                           th:href="@{/admin/products(search=${criteria.search}, category=${criteria.category}, status=${criteria.status}, sort=${criteria.sort}, page=${i})}"
+                                           th:href="@{/admin/products(search=${criteria.search}, category=${criteria.category}, status=${criteria.status}, sort=${criteria.sort}, includeDeleted=${includeDeleted}, page=${i})}"
                                            th:text="${i + 1}">1</a>
                                     </li>
                                     <li th:if="${i != currentPage and ((i == 3 and currentPage > 5) or (i == totalPages - 4 and currentPage < totalPages - 6))}" 
@@ -293,14 +287,14 @@
                                 <!-- 次のページ -->
                                 <li class="page-item" th:classappend="${currentPage >= totalPages - 1} ? 'disabled'">
                                     <a class="page-link"
-                                       th:href="@{/admin/products(search=${criteria.search}, category=${criteria.category}, status=${criteria.status}, sort=${criteria.sort}, page=${currentPage + 1})}">
+                                       th:href="@{/admin/products(search=${criteria.search}, category=${criteria.category}, status=${criteria.status}, sort=${criteria.sort}, includeDeleted=${includeDeleted}, page=${currentPage + 1})}">
                                         <i class="bi bi-chevron-right"></i>
                                     </a>
                                 </li>
                                 <!-- 最後のページ -->
                                 <li class="page-item" th:classappend="${currentPage >= totalPages - 1} ? 'disabled'">
                                     <a class="page-link"
-                                       th:href="@{/admin/products(search=${criteria.search}, category=${criteria.category}, status=${criteria.status}, sort=${criteria.sort}, page=${totalPages - 1})}">
+                                       th:href="@{/admin/products(search=${criteria.search}, category=${criteria.category}, status=${criteria.status}, sort=${criteria.sort}, includeDeleted=${includeDeleted}, page=${totalPages - 1})}">
                                         <i class="bi bi-chevron-double-right"></i>
                                     </a>
                                 </li>
@@ -372,15 +366,17 @@
                                 </div>
                             </div>
                             <div class="row mt-3">
-                                <div class="col-12">
-                                    <button type="submit" class="btn btn-success btn-lg me-2">
-                                        <i class="bi bi-check-circle"></i> 登録
-                                    </button>
-                                    <button type="reset" class="btn btn-secondary btn-lg">
-                                        <i class="bi bi-x-circle"></i> クリア
-                                    </button>
-                                    <a href="/admin/products/create" class="btn btn-outline-primary btn-lg ms-2">
-                                        <i class="bi bi-pencil-square"></i> 詳細入力フォームへ
+                                <div class="col-12 d-flex align-items-center">
+                                    <div>
+                                        <button type="submit" class="btn btn-success btn-lg me-2">
+                                            <i class="bi bi-check-circle"></i> 登録
+                                        </button>
+                                        <button type="reset" class="btn btn-secondary btn-lg">
+                                            <i class="bi bi-x-circle"></i> クリア
+                                        </button>
+                                    </div>
+                                    <a href="/admin/products/create" class="btn btn-success btn-lg ms-auto">
+                                        <i class="bi bi-plus-circle"></i> 新規商品登録
                                     </a>
                                 </div>
                             </div>
@@ -409,7 +405,7 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
                     <form id="deleteForm" method="post">
-                        <input type="hidden" id="deleteCsrfToken" name="_csrf" th:value="${_csrf.token}">
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                         <button type="submit" class="btn btn-danger">削除する</button>
                     </form>
                 </div>

--- a/src/test/java/com/inventory/inventory_management/controller/AdminInventoryControllerTest.java
+++ b/src/test/java/com/inventory/inventory_management/controller/AdminInventoryControllerTest.java
@@ -2,6 +2,7 @@ package com.inventory.inventory_management.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -208,6 +209,7 @@ class AdminInventoryControllerTest {
                 assertEquals("admin/inventory-detail", viewName);
                 assertEquals(product, model.getAttribute("product"));
                 assertEquals(transactions, model.getAttribute("transactions"));
+                assertNull(model.getAttribute("from"));
                 // デフォルトは在庫管理
                 assertEquals("在庫管理", model.getAttribute("parentLabel"));
                 assertEquals("/admin/inventory", model.getAttribute("parentUrl"));
@@ -228,6 +230,7 @@ class AdminInventoryControllerTest {
                 String viewName = adminInventoryController.showProductDetail(3, "products", model);
 
                 assertEquals("admin/inventory-detail", viewName);
+                assertEquals("products", model.getAttribute("from"));
                 assertEquals("商品管理", model.getAttribute("parentLabel"));
                 assertEquals("/admin/products", model.getAttribute("parentUrl"));
         }
@@ -247,6 +250,7 @@ class AdminInventoryControllerTest {
                 String viewName = adminInventoryController.showProductDetail(4, "unknown", model);
 
                 assertEquals("admin/inventory-detail", viewName);
+                assertEquals("unknown", model.getAttribute("from"));
                 assertEquals("在庫管理", model.getAttribute("parentLabel"));
                 assertEquals("/admin/inventory", model.getAttribute("parentUrl"));
         }

--- a/src/test/java/com/inventory/inventory_management/integration/AdminInventoryIntegrationTest.java
+++ b/src/test/java/com/inventory/inventory_management/integration/AdminInventoryIntegrationTest.java
@@ -526,7 +526,10 @@ class AdminInventoryIntegrationTest {
                                 .andReturn();
 
                 String content = result.getResponse().getContentAsString();
-                assertThat(content).contains("/admin/inventory").contains("在庫管理");
+                assertThat(content)
+                                .contains("/admin/inventory")
+                                .contains("在庫管理に戻る")
+                                .doesNotContain("商品管理に戻る");
         }
 
         @Test
@@ -539,7 +542,10 @@ class AdminInventoryIntegrationTest {
                                 .andReturn();
 
                 String content = result.getResponse().getContentAsString();
-                assertThat(content).contains("/admin/products").contains("商品管理");
+                assertThat(content)
+                                .contains("/admin/products")
+                                .contains("商品管理に戻る")
+                                .doesNotContain("在庫管理に戻る");
         }
 
         /**

--- a/src/test/java/com/inventory/inventory_management/service/AdminProductServiceTest.java
+++ b/src/test/java/com/inventory/inventory_management/service/AdminProductServiceTest.java
@@ -60,12 +60,30 @@ class AdminProductServiceTest {
         when(productRepository.findBySearchConditions(anyString(), anyString(), anyString(), any(PageRequest.class)))
                 .thenReturn(expected);
 
-        Page<Product> actual = adminProductService.searchProducts("test", "Electronics", "active", "name", 0);
+        Page<Product> actual = adminProductService.searchProducts(
+            "test", "Electronics", "active", "name", 0, false);
 
         assertEquals(expected, actual);
         verify(productRepository, times(1))
                 .findBySearchConditions(anyString(), anyString(), anyString(), any(PageRequest.class));
     }
+
+        @Test
+        @DisplayName("searchProducts: includeDeleted=true の場合は削除済み含む検索を使う")
+        void searchProducts_WithIncludeDeleted_DelegatesToIncludingDeletedRepository() {
+        Page<Product> expected = new PageImpl<>(List.of(new Product()));
+        when(productRepository.findBySearchConditionsIncludingDeleted(
+            anyString(), anyString(), anyString(), any(), any(), any(PageRequest.class)))
+            .thenReturn(expected);
+
+        Page<Product> actual = adminProductService.searchProducts(
+            "test", "Electronics", "active", "name", 0, true);
+
+        assertEquals(expected, actual);
+        verify(productRepository, times(1))
+            .findBySearchConditionsIncludingDeleted(
+                anyString(), anyString(), anyString(), any(), any(), any(PageRequest.class));
+        }
 
     @Test
     @DisplayName("getProductById: リポジトリ結果を返す")


### PR DESCRIPTION
- ProductSearchCriteriaDto に includeDeleted フィールドを追加
- AdminProductService.searchProducts() を6パラメータに拡張、条件分岐ロジックで Repository メソッド切り替え
- AdminProductController で includeDeleted パラメータを Service に渡し Model に設定
- products.html で削除済み商品フィルタチェックボックス追加、ページングリンクに includeDeleted 反映
- CSV ボタン削除、ボタン配置を在庫管理画面と統一
- admin-products.js の delete ボタンをイベントデリゲーション パターンに リファクタリング
- をテストケース追加: Service 分岐検証、Controller Model 属性検証、統合テストで表示フィルタリング検証
- テスト実行: 60 passed / 0 failed